### PR TITLE
Added token storage and hydration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,50 @@ appAuth.startAutomaticTokenRefresh().then(() => {
   console.log(response);
 });
 ```
+
+### Token Storage
+
+By default `LOAuth` will store the token in local storage and hydrate any existing session from there. To overwrite the storage location you can pass a storage object in options along with a custom storage key.
+
+```ts
+import { LOAuth } from '@lifeomic/app-tools';
+
+const appAuth = new LOAuth({
+  ...oauthConfig,
+  storageKey: 'my-super-awesome-key',
+  storage: {
+    getItem(key: string) {
+      return sessionStorage.getItem(key);
+    },
+    setItem(key: string, value: string) {
+      return sessionStorage.setItem(key, value);
+    },
+    removeItem(key: string) {
+      return sessionStorage.removeItem(key)
+    }
+  }
+});
+
+// or simply
+const appAuth = new LOAuth({
+  ...oauthConfig,
+  storageKey: 'my-super-awesome-key',
+  storage: sessionStorage,
+});
+```
+
+To opt-out of storing the token, you can pass in noop functions for storage
+
+```ts
+const noop = () => null;
+
+const appAuth = new LOAuth({
+  ...oauthConfig,
+  storageKey: 'my-super-awesome-key',
+  storage: {
+    getItem: noop,
+    setItem: noop,
+    removeItem: noop
+  }
+});
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/app-tools",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Common utilities for PHC app development",
   "main": "dist/index.js",
   "scripts": {

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,3 +1,3 @@
-module.exports = {
-  window
-};
+const win = window;
+
+export { win as window };

--- a/test/__snapshots__/LOAuth.test.ts.snap
+++ b/test/__snapshots__/LOAuth.test.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`refreshAccessToken attempts to exchange authorization code for access token 1`] = `
+Array [
+  Array [
+    "lo-app-tools-auth",
+    "{\\"access_token\\":\\"access_token\\",\\"expires_in\\":3600,\\"id_token\\":\\"id_token\\",\\"refresh_token\\":\\"refresh_token\\",\\"token_type\\":\\"Bearer\\",\\"expires\\":100}",
+  ],
+]
+`;
+
+exports[`refreshAccessToken performs refresh_token if called with expiringRefresh 1`] = `
+Array [
+  Array [
+    "lo-app-tools-auth",
+    "{\\"access_token\\":\\"access_token\\",\\"expires_in\\":3600,\\"id_token\\":\\"id_token\\",\\"refresh_token\\":\\"refresh_token\\",\\"token_type\\":\\"Bearer\\",\\"expires\\":100}",
+  ],
+  Array [
+    "lo-app-tools-auth",
+    "{\\"access_token\\":\\"access_token\\",\\"expires_in\\":3600,\\"id_token\\":\\"id_token\\",\\"refresh_token\\":\\"refresh_token\\",\\"token_type\\":\\"Bearer\\",\\"expires\\":100}",
+  ],
+]
+`;


### PR DESCRIPTION
* Added storage and storageKey params.
* Hydrate, store, and remove session info from a store.
* Added tests.
* updated ReadMe to include examples of overwriting the default store.
* Added public/private decorators for better TS support.
* Added a get accessToken method for apps not using the sign method.