### PR TITLE
Fixing errors for empty state object, and stale refresh tokens

### DIFF
--- a/src/LOAuth.ts
+++ b/src/LOAuth.ts
@@ -193,7 +193,7 @@ class LOAuth {
         });
 
         // Only create/store tokens from a valid response
-        if (response.status === 200) {
+        if (response.ok) {
           const responseJson = await response.json();
 
           this.token = this.client.createToken(

--- a/test/LOAuth.test.ts
+++ b/test/LOAuth.test.ts
@@ -30,7 +30,7 @@ jest.mock('../src/globals', () => ({
     },
     setInterval: jest.fn(),
     clearInterval: jest.fn(),
-    fetch: jest.fn().mockResolvedValue({ json: async () => tokenResponseJson, status: 200 })
+    fetch: jest.fn().mockResolvedValue({ json: async () => tokenResponseJson, ok: true })
   }
 }));
 
@@ -212,6 +212,7 @@ describe('with auth successfully created', () => {
     expect(globals.window.localStorage.setItem).toBeCalledTimes(1);
 
     globals.window.fetch.mockReturnValueOnce({
+      ok: false,
       status: 400,
       error: 'invalid_grant'
     });

--- a/test/__snapshots__/LOAuth.test.ts.snap
+++ b/test/__snapshots__/LOAuth.test.ts.snap
@@ -9,6 +9,19 @@ Array [
 ]
 `;
 
+exports[`with auth successfully created refreshAccessToken expiringRefresh handles refresh error 1`] = `
+Array [
+  Array [
+    "lo-app-tools-auth",
+    "{\\"access_token\\":\\"access_token\\",\\"expires_in\\":3600,\\"id_token\\":\\"id_token\\",\\"refresh_token\\":\\"refresh_token\\",\\"token_type\\":\\"Bearer\\",\\"expires\\":100}",
+  ],
+  Array [
+    "lo-app-tools-auth",
+    "{\\"access_token\\":\\"access_token\\",\\"expires_in\\":3600,\\"id_token\\":\\"id_token\\",\\"refresh_token\\":\\"refresh_token\\",\\"token_type\\":\\"Bearer\\",\\"expires\\":100}",
+  ],
+]
+`;
+
 exports[`with auth successfully created refreshAccessToken performs refresh_token if called with expiringRefresh 1`] = `
 Array [
   Array [


### PR DESCRIPTION
Primarily fixing an issue where an old token was saved in local storage and could not be refreshed due to expiry: https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html

```
response: {
  error: invalid_grant,
  status: 400
}
```
I updated a few code paths

- Only success refresh paths attempt to create/store a token
- Soon to expire localstorage tokens are removed from storage before attempting to refresh.

I also noticed an extra exception being thrown inside ClientOAuth2 because we were passing JSON.stringify({}) as the state value.  It was inconsequential in terms of the auth resolving eventually, but I figured I would clean that up too.