### PR TITLE
Remove the token from storage on a refresh error

### DIFF
--- a/src/LOAuth.ts
+++ b/src/LOAuth.ts
@@ -193,10 +193,11 @@ class LOAuth {
           this._storeTokenData(this.token);
         } else {
           // Go back to the no token path if refresh failed
-          // This will most likely result in an auth redirect
+          // This will result in an auth redirect
           this.token = null;
-          await this.refreshAccessToken();
-      }
+          this._removeTokenDataFromStorage();
+          await this.refreshAccessToken(options);
+        }
       }
     } catch (error) {
       const tokenFromStorage = this._getTokenDataFromStorage();

--- a/test/LOAuth.test.ts
+++ b/test/LOAuth.test.ts
@@ -231,6 +231,7 @@ describe('with auth successfully created', () => {
     );
     expect(ClientOAuth2.mock.results[0].value.createToken).toBeCalledTimes(0);
     expect(globals.window.localStorage.setItem).toBeCalledTimes(2);
+    expect(globals.window.localStorage.removeItem).toBeCalledTimes(1);
 
     expect(globals.window.localStorage.setItem.mock.calls).toMatchSnapshot();
   });


### PR DESCRIPTION
The work I'm doing on invalidating tokens with `adminGlobalUserSignOut` means we could start getting 401s and needing to refresh a token _even when it's not expired_. Currently, when that happens, we get into a loop because this code expects to only remove it from storage when it's expired. This fixes that to ensure it's removed immediately on refresh failure instead of yielding the old token from storage.