### PR TITLE
fix: token.exipresIn expects a concrete Date or a number *in seconds*…

### DIFF
--- a/src/LOAuth.ts
+++ b/src/LOAuth.ts
@@ -171,7 +171,7 @@ class LOAuth {
         refresh_token: storedData.refresh_token,
         token_type: 'Bearer'
       });
-      token.expiresIn(storedData.expires - Date.now());
+      token.expiresIn(new Date(storedData.expires));
 
       // the cookie clientId takes precedent over configured options
       this.clientOptions.clientId = storedData.clientId;

--- a/test/LOAuth.test.ts
+++ b/test/LOAuth.test.ts
@@ -359,14 +359,18 @@ describe('with auth successfully created', () => {
   });
 
   test('refreshAccessToken uses the token from the domain document cookie if it exists', async () => {
+    const expires = Date.now() + 100000;
+    const expiresDate = new Date(expires);
     globals.document.cookie = `${AUTH_STORAGE_KEY}=${JSON.stringify({
-      accessToken: 'foo',
-      refreshToken: 'bar',
+      access_token: 'foo',
+      refresh_token: 'bar',
       cookieDomain: 'us.skillspring.com',
-      expiresAt: Date.now() + 100000
+      expires
     })}`;
 
     await auth.refreshAccessToken();
+
+    expect(auth.token.expiresIn).toHaveBeenCalledWith(expiresDate);
     expect(ClientOAuth2.mock.results[0].value.createToken).toBeCalledTimes(1);
     expect(globals.window.fetch).toBeCalledTimes(0);
     expect(globals.document.cookie).toBe(


### PR DESCRIPTION
… but not a number in milliseconds. Unfortunately there's no type annotation about the units for the number. only a comment in the readme. 