### PR TITLE
Preserve query params in login redirect uri

### DIFF
--- a/src/LOAuth.ts
+++ b/src/LOAuth.ts
@@ -300,9 +300,10 @@ class LOAuth {
       } else {
         console.warn(error, 'Error refreshing access token - redirecting');
         if (this.clientOptions.loginRedirectUri) {
-          window.location.href = `${
-            this.clientOptions.loginRedirectUri
-          }?originalUrl=${encodeURIComponent(window.location.href)}`;
+          const redirectUri = new URL(this.clientOptions.loginRedirectUri);
+          redirectUri.searchParams.append('originalUrl', window.location.href);
+          
+          window.location.href = redirectUri.toString();
         } else {
           window.location.href = this.client.code.getUri();
         }

--- a/test/LOAuth.test.ts
+++ b/test/LOAuth.test.ts
@@ -282,6 +282,18 @@ describe('with auth successfully created', () => {
     expect(globals.window.location.href).toBe(expected);
   });
 
+  test('refreshAccessToken preserves existing query string in loginRedirectUri', async () => {
+    clientOAuth2.code.getToken.mockRejectedValue(new Error('unit test'));
+    globals.window.location.href = 'https://console.dev.skillspring.com';
+    const loginRedirectUri = 'https://apps.dev.lifeomic.com/skillspring-login/signup/?email=user%40example.com';
+    const expected = 'https://apps.dev.lifeomic.com/skillspring-login/signup/?email=user%40example.com&originalUrl=https%3A%2F%2Fconsole.dev.skillspring.com';
+
+    await new LOAuth({ ...ctorParams, loginRedirectUri }).refreshAccessToken();
+
+    expect(globals.window.location.href).toBe(expected);
+  });
+
+
   test('refreshAccessToken uses token from storage upon error', async () => {
     const appUrl = 'https://unit-test';
     globals.window.location.href = appUrl;


### PR DESCRIPTION
# Motivation
Accommodate urls with query strings in `LOAuth.Config.loginRedirectUri`. We have a [use case](https://github.com/lifeomic/connect-web-console/pull/511) in SkillSpring where `LOAuth.Config.loginRedirectUri` will contain a query parameter, which is not currently supported.

# Changes
- If loginRedirectUri contains a query string, append 'originalUrl' param with '&' instead of '?'.