### PR TITLE
Make options argument to startAutomaticTokenRefresh optional

### DIFF
--- a/src/LOAuth.ts
+++ b/src/LOAuth.ts
@@ -311,13 +311,12 @@ class LOAuth {
     }
   }
 
-  public async startAutomaticTokenRefresh(options: LOAuth.RefreshOptions) {
+  public async startAutomaticTokenRefresh(options: LOAuth.RefreshOptions = {}) {
     if (!this.token) {
       // Initiate initial auth token exchange
       await this.refreshAccessToken(options);
     }
 
-    options = options || {};
     if (!this.refreshInterval) {
       this.refreshInterval = window.setInterval(async () => {
         try {


### PR DESCRIPTION
The code was already treating it as optional and the examples in the README showed it as optional