### PR TITLE
fix: stop storing tokenType

### DIFF
--- a/src/APIBasedAuth.ts
+++ b/src/APIBasedAuth.ts
@@ -7,8 +7,7 @@ const TOKEN_KEYS = [
   'accessToken',
   'expiresIn',
   'idToken',
-  'refreshToken',
-  'tokenType'
+  'refreshToken'
 ] as const;
 const DEFAULT_STORAGE_KEYS: APIBasedAuth.StorageKeys = {
   accessToken: `${API_AUTH_STORAGE_KEY}.accessToken`,
@@ -16,7 +15,6 @@ const DEFAULT_STORAGE_KEYS: APIBasedAuth.StorageKeys = {
   idToken: `${API_AUTH_STORAGE_KEY}.idToken`,
   refreshToken: `${API_AUTH_STORAGE_KEY}.refreshToken`,
   session: `${API_AUTH_STORAGE_KEY}.session`,
-  tokenType: `${API_AUTH_STORAGE_KEY}.tokenType`,
   username: `${API_AUTH_STORAGE_KEY}.username`
 };
 
@@ -39,7 +37,6 @@ const DEFAULT_STORAGE_KEYS: APIBasedAuth.StorageKeys = {
  *     idToken: 'custom_identity_token_key',
  *     refreshToken: 'custom_refresh_token_key',
  *     session: 'custom_session_key',
- *     tokenType: 'custom_token_type_key',
  *     username: 'custom_username_key',
  *   },
  * });
@@ -67,7 +64,6 @@ const DEFAULT_STORAGE_KEYS: APIBasedAuth.StorageKeys = {
  *     idToken: 'custom_identity_token_key',
  *     refreshToken: 'custom_refresh_token_key',
  *     session: 'custom_session_key',
- *     tokenType: 'custom_token_type_key',
  *     username: 'custom_username_key',
  *   },
  * });
@@ -76,7 +72,6 @@ const DEFAULT_STORAGE_KEYS: APIBasedAuth.StorageKeys = {
  * If nothing is passed in, all of the default keys will be used and values stored.
  *   storageKeys = {
  *     expiresIn: undefined,
- *     tokenType: undefined,
  *   };
  *
  * Reasoning for decisions made:
@@ -314,7 +309,6 @@ declare namespace APIBasedAuth {
     expiresIn: number;
     idToken: string;
     refreshToken: string;
-    tokenType: string;
   };
 
   export type VerifyPasswordlessAuthData = {

--- a/test/APIBasedAuth.test.ts
+++ b/test/APIBasedAuth.test.ts
@@ -27,7 +27,6 @@ const DEFAULT_ACCESS_TOKEN_KEY = `${API_AUTH_STORAGE_KEY}.accessToken`;
 const DEFAULT_EXPIRES_IN_KEY = `${API_AUTH_STORAGE_KEY}.expiresIn`;
 const DEFAULT_ID_TOKEN_KEY = `${API_AUTH_STORAGE_KEY}.idToken`;
 const DEFAULT_REFRESH_TOKEN_KEY = `${API_AUTH_STORAGE_KEY}.refreshToken`;
-const DEFAULT_TOKEN_TYPE_KEY = `${API_AUTH_STORAGE_KEY}.tokenType`;
 const mockLoginMethods = [
   {
     type: 'OIDC',
@@ -43,8 +42,7 @@ const mockToken = {
   accessToken: 'access_token',
   expiresIn: 3600,
   idToken: 'id_token',
-  refreshToken: 'refresh_token',
-  tokenType: 'Bearer'
+  refreshToken: 'refresh_token'
 };
 const promiseWrapStorage = (storage: typeof globals.window.localStorage) => ({
   getItem: (key) => Promise.resolve(storage.getItem(key)),
@@ -95,8 +93,7 @@ beforeEach(() => {
     clientId: '7cbji8hkta84ons79j34qcfdci',
     storage: promiseWrapStorage(globals.window.localStorage),
     storageKeys: {
-      expiresIn: undefined,
-      tokenType: undefined
+      expiresIn: undefined
     }
   };
 });
@@ -283,7 +280,7 @@ describe('with auth successfully created', () => {
       2,
       'custom_username'
     );
-    expect(globals.window.localStorage.setItem).toHaveBeenCalledTimes(5);
+    expect(globals.window.localStorage.setItem).toHaveBeenCalledTimes(4);
     expect(globals.window.localStorage.setItem).toHaveBeenNthCalledWith(
       1,
       DEFAULT_ACCESS_TOKEN_KEY,
@@ -303,11 +300,6 @@ describe('with auth successfully created', () => {
       4,
       DEFAULT_REFRESH_TOKEN_KEY,
       mockToken.refreshToken
-    );
-    expect(globals.window.localStorage.setItem).toHaveBeenNthCalledWith(
-      5,
-      DEFAULT_TOKEN_TYPE_KEY,
-      mockToken.tokenType
     );
 
     expect(clientAxios.post).toHaveBeenCalledWith('/passwordless-auth/verify', {


### PR DESCRIPTION
## Motivation
I'd like to propose _not_ storing the `tokenType` variable. Why:
- Its value is only ever `Bearer`.
- Not all of our authentication methods return a `tokenType` value.
- Storing it adds "one more async call" -- removing it will give a small performance benefit.