### PR TITLE
Add setTokens method to api based auth

### DIFF
--- a/src/APIBasedAuth.ts
+++ b/src/APIBasedAuth.ts
@@ -206,6 +206,20 @@ class APIBasedAuth {
     return data;
   }
 
+  /**
+   * Sets credentials into the store. This shouldn't typically be
+   * needed to be used directly as app-tools will handle it any time
+   * auth is handled through one of its supported auth methods.
+   * However, in the case that credentials are received some other
+   * way this can be used to store them.
+   */
+  public async setTokens(tokens: Omit<APIBasedAuth.Tokens, '_type'>) {
+    await this._store({
+      _type: 'token',
+      ...tokens
+    });
+  }
+
   public async logout() {
     await Promise.all([
       this._removeFromStorage('session'),

--- a/test/APIBasedAuth.test.ts
+++ b/test/APIBasedAuth.test.ts
@@ -291,21 +291,7 @@ describe('with auth successfully created', () => {
       'custom_username'
     );
     expect(globals.window.localStorage.setItem).toHaveBeenCalledTimes(3);
-    expect(globals.window.localStorage.setItem).toHaveBeenNthCalledWith(
-      1,
-      DEFAULT_ACCESS_TOKEN_KEY,
-      mockToken.accessToken
-    );
-    expect(globals.window.localStorage.setItem).toHaveBeenNthCalledWith(
-      2,
-      DEFAULT_ID_TOKEN_KEY,
-      mockToken.idToken
-    );
-    expect(globals.window.localStorage.setItem).toHaveBeenNthCalledWith(
-      3,
-      DEFAULT_REFRESH_TOKEN_KEY,
-      mockToken.refreshToken
-    );
+    assertTokenStorage();
 
     expect(clientAxios.post).toHaveBeenCalledWith('/passwordless-auth/verify', {
       clientId: params.clientId,
@@ -646,4 +632,29 @@ describe('with auth successfully created', () => {
 
     expect(newAccessToken).toBe(mockToken.accessToken);
   });
+
+  test('setTokens sets tokens into storage', async () => {
+    auth.clientOptions.storage.getItem('');
+    await auth.setTokens(mockToken);
+    expect(globals.window.localStorage.setItem).toHaveBeenCalledTimes(3);
+    assertTokenStorage();
+  });
 });
+
+const assertTokenStorage = () => {
+  expect(globals.window.localStorage.setItem).toHaveBeenNthCalledWith(
+    1,
+    DEFAULT_ACCESS_TOKEN_KEY,
+    mockToken.accessToken
+  );
+  expect(globals.window.localStorage.setItem).toHaveBeenNthCalledWith(
+    2,
+    DEFAULT_ID_TOKEN_KEY,
+    mockToken.idToken
+  );
+  expect(globals.window.localStorage.setItem).toHaveBeenNthCalledWith(
+    3,
+    DEFAULT_REFRESH_TOKEN_KEY,
+    mockToken.refreshToken
+  );
+};


### PR DESCRIPTION
## Motivations

Sometimes there might be cases where authentication happens outside of app-tools and we still want easy access to setting tokens in the correct place with the configured store.

The one use case right now is within the Preventia Client UI app which does SSO through expo packages in which case we can use this method to set the credentials into the store