### PR TITLE
feat: add clientId to login-methods request

### DIFF
--- a/src/APIBasedAuth.ts
+++ b/src/APIBasedAuth.ts
@@ -153,7 +153,9 @@ class APIBasedAuth {
     const { data } = await this.appsClient.get<
       APIBasedAuth.LoginMethod[],
       AxiosResponse<APIBasedAuth.LoginMethod[]>
-    >('/login-methods', { params: { login } });
+    >('/login-methods', {
+      params: { login, clientId: this.clientOptions.clientId }
+    });
     return data;
   }
 

--- a/test/APIBasedAuth.test.ts
+++ b/test/APIBasedAuth.test.ts
@@ -342,6 +342,12 @@ describe('with auth successfully created', () => {
       }))
     );
     expect(clientAxios.get).toHaveBeenCalledTimes(1);
+    expect(clientAxios.get).toHaveBeenNthCalledWith(1, '/login-methods', {
+      params: {
+        login: 'test_username',
+        clientId: auth.clientOptions.clientId
+      }
+    });
 
     const loginMethods2 = await auth.getLoginMethods('test_username');
 
@@ -352,6 +358,12 @@ describe('with auth successfully created', () => {
       }))
     );
     expect(clientAxios.get).toHaveBeenCalledTimes(2);
+    expect(clientAxios.get).toHaveBeenNthCalledWith(2, '/login-methods', {
+      params: {
+        login: 'test_username',
+        clientId: auth.clientOptions.clientId
+      }
+    });
   });
 
   test('initPasswordlessAuth with session storageKey removed', async () => {


### PR DESCRIPTION
## Motivation
Adding this new query parameter to the `login-methods` endpoint.