### PR TITLE
feat: add confirm signup method

### DIFF
--- a/src/APIBasedAuth.ts
+++ b/src/APIBasedAuth.ts
@@ -228,6 +228,25 @@ class APIBasedAuth {
   }
 
   /**
+   * Confirms and completes a new user's signup. This requires
+   * a confirmation code to prove that the user has access to the
+   * provided email address
+   */
+  public async confirmSignup(
+    input: Omit<APIBasedAuth.ConfirmSignupData, 'clientId'>
+  ) {
+    const { data } = await this.apiClient.post<
+      APIBasedAuth.ConfirmSignupResponse,
+      AxiosResponse<APIBasedAuth.ConfirmSignupResponse>,
+      APIBasedAuth.ConfirmSignupData
+    >('/confirm', {
+      clientId: this.clientOptions.clientId,
+      ...input
+    });
+    return data;
+  }
+
+  /**
    * Sets credentials into the store. This shouldn't typically be
    * needed to be used directly as app-tools will handle it any time
    * auth is handled through one of its supported auth methods.
@@ -423,6 +442,23 @@ declare namespace APIBasedAuth {
     phone?: string;
     givenName?: string;
     familyName?: string;
+  };
+
+  export type ConfirmSignupResponse = {
+    accessToken: string;
+    refreshToken: string;
+    idToken: string;
+  };
+
+  export type ConfirmSignupData = {
+    clientId: string;
+    /** Username or email of the user being confirmed */
+    username: string;
+    /**
+     * The code that should have been made available to the user
+     * through the email sent to the provided email address
+     */
+    code: string;
   };
 }
 

--- a/src/APIBasedAuth.ts
+++ b/src/APIBasedAuth.ts
@@ -243,6 +243,7 @@ class APIBasedAuth {
       clientId: this.clientOptions.clientId,
       ...input
     });
+    await this.setTokens(data);
     return data;
   }
 

--- a/test/APIBasedAuth.test.ts
+++ b/test/APIBasedAuth.test.ts
@@ -607,6 +607,7 @@ describe('with auth successfully created', () => {
       refreshToken: 'mock-refresh-token'
     };
     jest.spyOn(clientAxios, 'post').mockResolvedValue({ data: mockResponse });
+    const setTokensSpy = jest.spyOn(auth, 'setTokens');
 
     const input: Omit<APIBasedAuth.ConfirmSignupData, 'clientId'> = {
       username: 'test.user',
@@ -622,6 +623,8 @@ describe('with auth successfully created', () => {
       clientId: params.clientId,
       ...input
     });
+    expect(setTokensSpy).toHaveBeenCalledTimes(1);
+    expect(setTokensSpy).toHaveBeenLastCalledWith(mockResponse);
   });
 
   test('getAccessToken returns undefined with no storage set', async () => {

--- a/test/APIBasedAuth.test.ts
+++ b/test/APIBasedAuth.test.ts
@@ -600,6 +600,30 @@ describe('with auth successfully created', () => {
     });
   });
 
+  test('confirmSignup makes expected request', async () => {
+    const mockResponse: APIBasedAuth.ConfirmSignupResponse = {
+      accessToken: 'mock-access-token',
+      idToken: 'mock-access-token',
+      refreshToken: 'mock-refresh-token'
+    };
+    jest.spyOn(clientAxios, 'post').mockResolvedValue({ data: mockResponse });
+
+    const input: Omit<APIBasedAuth.ConfirmSignupData, 'clientId'> = {
+      username: 'test.user',
+      code
+    };
+
+    const result = await auth.confirmSignup(input);
+
+    expect(result).toStrictEqual(mockResponse);
+
+    expect(clientAxios.post).toHaveBeenCalledTimes(1);
+    expect(clientAxios.post).toHaveBeenCalledWith('/confirm', {
+      clientId: params.clientId,
+      ...input
+    });
+  });
+
   test('getAccessToken returns undefined with no storage set', async () => {
     delete params.storage;
     auth = new APIBasedAuth(params);


### PR DESCRIPTION
## Motivation

~based on #83~

We want to provide a way to sign-up Platform users easily, especially in 3rd party apps like Preventia.

