### PR TITLE
feat: make username not required in signup method

### DIFF
--- a/src/APIBasedAuth.ts
+++ b/src/APIBasedAuth.ts
@@ -420,10 +420,14 @@ declare namespace APIBasedAuth {
 
   export type InitiateSignupData = {
     clientId: string;
-    /** Unique username for the user. A required field */
-    username: string;
     /** Unique email address for the user. A required field */
     email: string;
+    /**
+     * Unique username for the user. In the case that a username
+     * is not provided, the server will attempt to generate a
+     * unique string based on the provided email address.
+     */
+    username?: string;
     /**
      * Web url where the user registration takes place.
      * @example 'https://example.com'

--- a/test/APIBasedAuth.test.ts
+++ b/test/APIBasedAuth.test.ts
@@ -573,7 +573,34 @@ describe('with auth successfully created', () => {
     });
   });
 
-  test('initiateSignup makes expected request', async () => {
+  test('initiateSignup makes expected request (while providing username)', async () => {
+    const mockResponse: APIBasedAuth.InitiateSignupResponse = {
+      userConfirmed: false
+    };
+    jest.spyOn(clientAxios, 'post').mockResolvedValue({ data: mockResponse });
+
+    const input: Omit<APIBasedAuth.InitiateSignupData, 'clientId'> = {
+      email: 'test.user@test.com',
+      phone: '+12223334444',
+      username: 'test.user',
+      password: 'test-password',
+      familyName: 'test',
+      givenName: 'user',
+      originalUrl: 'https://test.com'
+    };
+
+    const result = await auth.initiateSignup(input);
+
+    expect(result).toStrictEqual(mockResponse);
+
+    expect(clientAxios.post).toHaveBeenCalledTimes(1);
+    expect(clientAxios.post).toHaveBeenCalledWith('/signup', {
+      clientId: params.clientId,
+      ...input
+    });
+  });
+
+  test('initiateSignup makes expected request (without providing username)', async () => {
     const mockResponse: APIBasedAuth.InitiateSignupResponse = {
       userConfirmed: false
     };

--- a/test/APIBasedAuth.test.ts
+++ b/test/APIBasedAuth.test.ts
@@ -581,8 +581,8 @@ describe('with auth successfully created', () => {
 
     const input: Omit<APIBasedAuth.InitiateSignupData, 'clientId'> = {
       email: 'test.user@test.com',
-      phone: undefined,
-      username: 'test.user',
+      phone: '+12223334444',
+      username: undefined,
       password: 'test-password',
       familyName: 'test',
       givenName: 'user',


### PR DESCRIPTION
## Motivation

This feature first needs to be done and merged https://github.com/lifeomic/apps-auth/pull/292

If a username is not provided, while still technically required, it can be auto generated for the user based on the email address. The generation does use a random id and checks for unique usernames so it will not generate the same username for given the same email address.