### PR TITLE
fix: use correct client for signup methods

### DIFF
--- a/src/APIBasedAuth.ts
+++ b/src/APIBasedAuth.ts
@@ -216,7 +216,7 @@ class APIBasedAuth {
   public async initiateSignup(
     input: Omit<APIBasedAuth.InitiateSignupData, 'clientId'>
   ) {
-    const { data } = await this.apiClient.post<
+    const { data } = await this.appsClient.post<
       APIBasedAuth.InitiateSignupResponse,
       AxiosResponse<APIBasedAuth.InitiateSignupResponse>,
       APIBasedAuth.InitiateSignupData
@@ -235,7 +235,7 @@ class APIBasedAuth {
   public async confirmSignup(
     input: Omit<APIBasedAuth.ConfirmSignupData, 'clientId'>
   ) {
-    const { data } = await this.apiClient.post<
+    const { data } = await this.appsClient.post<
       APIBasedAuth.ConfirmSignupResponse,
       AxiosResponse<APIBasedAuth.ConfirmSignupResponse>,
       APIBasedAuth.ConfirmSignupData


### PR DESCRIPTION
## Motivation

These methods are using the wrong clients making the requests fail because it is pointing to wrong domains. This was broken when I originally added these methods  🤦 